### PR TITLE
Change API

### DIFF
--- a/src/Slim/Controller/AbstractController.php
+++ b/src/Slim/Controller/AbstractController.php
@@ -23,13 +23,6 @@ abstract class AbstractController
     protected $logger;
 
     /**
-     * HTTP response code
-     *
-     * @var int
-     */
-    private $httpResponseCode = 200;
-
-    /**
      * Construct the controller
      *
      * @param LoggerInterface   $logger   A PSR-3 logger interface
@@ -91,28 +84,6 @@ abstract class AbstractController
         } else {
             return $this->__invoke($request, $response, $uriArgs);
         }
-    }
-
-    /**
-     * Set the HTTP response code
-     *
-     * @param int $httpResponseCode     HTTP response code
-     *
-     * @return void
-     */
-    public function setHttpResponseCode(int $httpResponseCode)
-    {
-        $this->httpResponseCode = $httpResponseCode;
-    }
-
-    /**
-     * Get the HTTP response code
-     *
-     * @return int
-     */
-    public function getHttpResponseCode(): int
-    {
-        return $this->httpResponseCode;
     }
 
     /**

--- a/src/Slim/Controller/Traits/ControllerTraitJsonResponse.php
+++ b/src/Slim/Controller/Traits/ControllerTraitJsonResponse.php
@@ -39,13 +39,11 @@ trait ControllerTraitJsonResponse
      * sets a `Content-type application/json` response header.
      *
      * @param  Response    $response           Response interface
-     * @param  int         $httpResponseCode   HTTP response code
      * @return Response
      */
-    protected function writeJsonBody(Response $response, int $httpResponseCode = 200) : Response
+    protected function writeJsonBody(Response $response) : Response
     {
         return $response
-                ->withStatus($httpResponseCode)
                 ->withHeader('Content-type', 'application/json')
                 ->write(json_encode(
                     $this->jsonResponseBody,

--- a/tests/Slim/Controller/AbstractControllerTest.php
+++ b/tests/Slim/Controller/AbstractControllerTest.php
@@ -40,16 +40,6 @@ class AbstractControllerTest extends TestCase
         );
     }
 
-    public function testSetGetHttpResponseCode()
-    {
-        $logger = $this->getDebugLogger();
-        $controller = $this->getMockForAbstractClass(AbstractController::class, [$logger]);
-
-        $controller->setHttpResponseCode(400);
-
-        $this->assertEquals(400, $controller->getHttpResponseCode());
-    }
-
     public function testMockInvoke()
     {
         $logger = $this->getDebugLogger();

--- a/tests/Slim/Controller/Traits/ControllerTraitJsonResponseTest.php
+++ b/tests/Slim/Controller/Traits/ControllerTraitJsonResponseTest.php
@@ -28,7 +28,8 @@ class ControllerTraitJsonResponseTest extends TestCase
         $writeJsonBodyMethod->setAccessible(true);
         $response = $writeJsonBodyMethod->invokeArgs($mock, [new Response]);
         $this->assertTrue(is_a($response, 'Slim\Http\Response'));
-        $response = $writeJsonBodyMethod->invokeArgs($mock, [new Response, 401]);
+        $this->assertEquals(200, $response->getStatusCode());
+        $response = $writeJsonBodyMethod->invokeArgs($mock, [new Response(401)]);
         $this->assertEquals(401, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
Deprecate methods:

* `Serato\SwsApp\Slim\Controller\AbstractController::setHttpResponseCode`
* `Serato\SwsApp\Slim\Controller\AbstractController::getHttpResponseCode`

Change method API:

* Remove `$httpResponseCode` argument from `Serato\SwsApp\Slim\Controller\Traits\writeJsonBody` method