### PR TITLE
[WEB-7579] Update access token middleware with latest serato/jwt changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"php": "^7.1",
 		"slim/slim": "^3.0.0",
-		"serato/jwt": "^1.0.0",
+		"serato/jwt": "^2.0.0",
 		"aws/aws-sdk-php": "^3.0",
 		"propel/propel": "2.0.0-alpha8",
 		"willdurand/negotiation": "~2.2.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"php": "^7.1",
 		"slim/slim": "^3.0.0",
-		"serato/jwt": "^2.0.0",
+		"serato/jwt": "^2.0.1",
 		"aws/aws-sdk-php": "^3.0",
 		"propel/propel": "2.0.0-alpha8",
 		"willdurand/negotiation": "~2.2.0",

--- a/src/Service/CountryServiceInterface.php
+++ b/src/Service/CountryServiceInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Serato\SwsApp\Service;
 
 /**

--- a/src/Slim/Controller/Traits/ControllerTraitValidateRequiredRequestBodyParams.php
+++ b/src/Slim/Controller/Traits/ControllerTraitValidateRequiredRequestBodyParams.php
@@ -11,7 +11,6 @@ use Psr\Http\Message\ResponseInterface as Response;
  */
 trait ControllerTraitValidateRequiredRequestBodyParams
 {
-
     /**
      * Array of required named parameters for PUT and POST requests
      *

--- a/src/Slim/Middleware/AccessScopes/AccessToken.php
+++ b/src/Slim/Middleware/AccessScopes/AccessToken.php
@@ -64,6 +64,7 @@ class AccessToken extends AbstractAccessScopesMiddleware
      * @param LoggerInterface           $logger             PSR-3 logger interface
      * @param CacheItemPoolInterface    $cache              PSR-6 cache item pool
      * @param string                    $webServiceName     Name of the host web application
+     * @param \Memcached                $memcached          Memcache connection
      *
      */
     public function __construct(

--- a/src/Slim/Middleware/AccessScopes/AccessToken.php
+++ b/src/Slim/Middleware/AccessScopes/AccessToken.php
@@ -53,6 +53,13 @@ class AccessToken extends AbstractAccessScopesMiddleware
     protected $cache;
 
     /**
+     * Memcached connection
+     * 
+     * @var \Memcached
+     */
+    protected $memcached;
+
+    /**
      * @param Sdk                       $awsSdk             AWS SDK v3.x
      * @param LoggerInterface           $logger             PSR-3 logger interface
      * @param CacheItemPoolInterface    $cache              PSR-6 cache item pool
@@ -63,11 +70,13 @@ class AccessToken extends AbstractAccessScopesMiddleware
         Sdk $awsSdk,
         LoggerInterface $logger,
         CacheItemPoolInterface $cache,
+        \Memcached $memcached,
         string $webServiceName
     ) {
         $this->awsSdk = $awsSdk;
         $this->logger = $logger;
         $this->cache = $cache;
+        $this->memcached = $memcached;
         $this->webServiceName = $webServiceName;
     }
 
@@ -96,7 +105,7 @@ class AccessToken extends AbstractAccessScopesMiddleware
             $accessToken = new JwtAccessToken($this->getAwsSdk());
             try {
                 $accessToken->parseTokenString((string)$tokenString, $this->cache);
-                $accessToken->validate($this->webServiceName);
+                $accessToken->validate($this->webServiceName, $this->memcached);
 
                 $scopes = $this->getAccessTokenScopes($accessToken);
 

--- a/src/Slim/Middleware/AccessScopes/AccessToken.php
+++ b/src/Slim/Middleware/AccessScopes/AccessToken.php
@@ -54,7 +54,7 @@ class AccessToken extends AbstractAccessScopesMiddleware
 
     /**
      * Memcached connection
-     * 
+     *
      * @var \Memcached
      */
     protected $memcached;

--- a/src/Validation/RequestValidationInterface.php
+++ b/src/Validation/RequestValidationInterface.php
@@ -15,7 +15,7 @@ interface RequestValidationInterface
      * @param array $validationRules
      * @param array $customRules
      * @param array $exceptions
-     * 
+     *
      */
     public function validateRequestData(
         Request $request,

--- a/tests/Slim/Middleware/AccessControlAllowOriginTest.php
+++ b/tests/Slim/Middleware/AccessControlAllowOriginTest.php
@@ -17,7 +17,7 @@ class AccessControlAllowOriginTest extends TestCase
     /**
      * Create a Request object with no value provided for the `Origin` header.
      * Create an empty Response object.
-     * 
+     *
      * Execute the middleware and get the returned Response object.
      *
      * Confirm that the Response object has:
@@ -40,7 +40,7 @@ class AccessControlAllowOriginTest extends TestCase
     /**
      * Create a Request object with a value provided for the `Origin` header.
      * Create an empty Response object.
-     * 
+     *
      * Execute the middleware and get the returned Response object.
      *
      * Confirm that the Response object has:
@@ -69,7 +69,7 @@ class AccessControlAllowOriginTest extends TestCase
     /**
      * Create a Request object with a value provided for the `Origin` header.
      * Create a Response object with a `Vary` header that contains an initial value.
-     * 
+     *
      * Execute the middleware and get the returned Response object.
      *
      * Confirm that the Response object has:
@@ -86,7 +86,7 @@ class AccessControlAllowOriginTest extends TestCase
 
         $request = Request::createFromEnvironmentBuilder(EnvironmentBuilder::create())
                         ->withHeader('Origin', $origin);
-        
+
         $response = new Response();
         $response = $middleware(
             $request,

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -22,7 +22,7 @@ class RequestValidationTest extends TestCase
      * @param string|null $errorExpected
      * @param array $customRules
      * @param array $exceptions
-     * 
+     *
      * @group validation
      */
     public function testRest(

--- a/tests/resources/propel/model/License.php
+++ b/tests/resources/propel/model/License.php
@@ -16,5 +16,4 @@ use Serato\SwsApp\Test\Propel\Model\Base\License as BaseLicense;
  */
 class License extends BaseLicense
 {
-
 }

--- a/tests/resources/propel/model/LicenseQuery.php
+++ b/tests/resources/propel/model/LicenseQuery.php
@@ -16,5 +16,4 @@ use Serato\SwsApp\Test\Propel\Model\Base\LicenseQuery as BaseLicenseQuery;
  */
 class LicenseQuery extends BaseLicenseQuery
 {
-
 }

--- a/tests/resources/propel/model/LicenseType.php
+++ b/tests/resources/propel/model/LicenseType.php
@@ -16,5 +16,4 @@ use Serato\SwsApp\Test\Propel\Model\Base\LicenseType as BaseLicenseType;
  */
 class LicenseType extends BaseLicenseType
 {
-
 }

--- a/tests/resources/propel/model/LicenseTypeQuery.php
+++ b/tests/resources/propel/model/LicenseTypeQuery.php
@@ -16,5 +16,4 @@ use Serato\SwsApp\Test\Propel\Model\Base\LicenseTypeQuery as BaseLicenseTypeQuer
  */
 class LicenseTypeQuery extends BaseLicenseTypeQuery
 {
-
 }

--- a/tests/resources/propel/model/Product.php
+++ b/tests/resources/propel/model/Product.php
@@ -16,5 +16,4 @@ use Serato\SwsApp\Test\Propel\Model\Base\Product as BaseProduct;
  */
 class Product extends BaseProduct
 {
-
 }

--- a/tests/resources/propel/model/ProductQuery.php
+++ b/tests/resources/propel/model/ProductQuery.php
@@ -16,5 +16,4 @@ use Serato\SwsApp\Test\Propel\Model\Base\ProductQuery as BaseProductQuery;
  */
 class ProductQuery extends BaseProductQuery
 {
-
 }

--- a/tests/resources/propel/model/ProductType.php
+++ b/tests/resources/propel/model/ProductType.php
@@ -16,5 +16,4 @@ use Serato\SwsApp\Test\Propel\Model\Base\ProductType as BaseProductType;
  */
 class ProductType extends BaseProductType
 {
-
 }

--- a/tests/resources/propel/model/ProductTypeQuery.php
+++ b/tests/resources/propel/model/ProductTypeQuery.php
@@ -16,5 +16,4 @@ use Serato\SwsApp\Test\Propel\Model\Base\ProductTypeQuery as BaseProductTypeQuer
  */
 class ProductTypeQuery extends BaseProductTypeQuery
 {
-
 }


### PR DESCRIPTION
This is a breaking change as the middleware now requires memcached to be passed in.

The JWT access token class does an additional check to see if its parent refresh token has been invalidated through memcache.