### PR TITLE
[TDO-391] Parameterize client IP address header in GeoIpLookup

### DIFF
--- a/src/Slim/Middleware/GeoIpLookup.php
+++ b/src/Slim/Middleware/GeoIpLookup.php
@@ -2,7 +2,6 @@
 
 namespace Serato\SwsApp\Slim\Middleware;
 
-use Slim\Http\Body;
 use Slim\Handlers\AbstractHandler;
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -29,14 +28,19 @@ class GeoIpLookup extends AbstractHandler
     /* @var string */
     private $geoLiteDbPath;
 
+    /* @var string */
+    private $realIpHeader;
+
     /**
      * Constructs the object
      *
      * @param string $geoLiteDbPath     Path to a GeoLite2 database file
+     * @param string $realIpHeader      Name of the HTTP header that contains the client's real IP address
      */
-    public function __construct(string $geoLiteDbPath)
+    public function __construct(string $geoLiteDbPath, string $realIpHeader = '')
     {
         $this->geoLiteDbPath = $geoLiteDbPath;
+        $this->realIpHeader = $realIpHeader === '' ? 'X-Forwarded-For' : $realIpHeader;
     }
 
     /**
@@ -50,8 +54,12 @@ class GeoIpLookup extends AbstractHandler
      */
     public function __invoke(Request $request, Response $response, callable $next): Response
     {
-        $ip = $request->getServerParam('HTTP_X_FORWARDED_FOR', '');
-        if ($ip === '') {
+        if ($this->realIpHeader !== '' && $request->hasHeader($this->realIpHeader)) {
+            $header = $request->getHeaderLine($this->realIpHeader);
+
+            // Some client IP headers, like 'CloudFront-Viewer-Address', include a port number
+            $ip = explode(':', $header)[0];
+        } else {
             $ip = $request->getServerParam('REMOTE_ADDR', '');
         }
 


### PR DESCRIPTION
https://serato.atlassian.net/browse/TDO-391

- Allow the header used to retrieve the client IP to be customised via a constructor param to the `GeoIpLookup` middleware
- Accommodate the appended port number in `CloudFront-Viewer-Address` headers

I've tested this on [a branch for the DA Service](https://github.com/serato/da-serato-com/compare/tdo-391-cdn-viewer-ip?expand=1), but it may be better to wait for https://serato.atlassian.net/browse/WEB-7575 to be merged before updating the other services. I noticed that my changes are almost identical to the WEB-7586 branch. 

The updates required for each service will be to load the header from `REAL_IP_HEADER` in the config, pass this new argument to `GeoIpLookup`, and bump the `serato/sws-bootstrap` version.

This changes the API but shouldn't be a breaking change, as the new argument has a default value.