### PR TITLE
[WEB-8002] updated validateRequestData

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"symfony/property-access": "^4.4"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~7.0",
+		"phpunit/phpunit": "^7.5.20",
 		"squizlabs/php_codesniffer": "~3.6",
 		"monolog/monolog": "^1.21.0",
 		"serato/slimulator": "^1.0.0",

--- a/src/Validation/RequestValidation.php
+++ b/src/Validation/RequestValidation.php
@@ -24,7 +24,7 @@ class RequestValidation implements RequestValidationInterface
         array $validationRules,
         array $customRules = [],
         array $exceptions = []
-    ): void {
+    ): array {
         $requestBody = $request->getParsedBody();
         $validator   = new Validator();
 
@@ -44,7 +44,7 @@ class RequestValidation implements RequestValidationInterface
 
         $validation->validate();
         if (!$validation->fails()) {
-            return;
+            return $validation->getValidatedData();
         }
 
         $required = [];

--- a/src/Validation/RequestValidationInterface.php
+++ b/src/Validation/RequestValidationInterface.php
@@ -22,5 +22,5 @@ interface RequestValidationInterface
         array $validationRules,
         array $customRules = [],
         array $exceptions = []
-    ): void;
+    ): array;
 }

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -38,7 +38,6 @@ class RequestValidationTest extends TestCase
      * @param string|null $errorExpected
      * @param array $customRules
      * @param array $exceptions
-     * @param array|null $expectedRequest
      * @group validation
      */
     public function testValidateRequestData(

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -48,14 +48,13 @@ class RequestValidationTest extends TestCase
         array $customRules = [],
         array $exceptions = [],
         ?array $expectedResult = null
-    ): void
-    {
+    ): void {
         $this->requestMock->shouldReceive('getParsedBody')
             ->andReturn($requestBody);
 
         if (!is_null($errorExpected)) {
             $this->expectException($errorExpected);
-        } else if(is_null($expectedResult)){
+        } elseif (is_null($expectedResult)) {
             $this->expectNotToPerformAssertions();
         }
 

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -15,8 +15,14 @@ use Serato\SwsApp\Validation\RequestValidation;
 class RequestValidationTest extends TestCase
 {
 
-
+    /**
+     * @var RequestValidation
+     */
     protected $validation;
+
+    /**
+     * @var Request
+     */
     protected $requestMock;
 
     protected function setUp()
@@ -35,13 +41,12 @@ class RequestValidationTest extends TestCase
      * @param array|null $expectedRequest
      * @group validation
      */
-    public function testRest(
+    public function testValidateRequestData(
         array $requestBody,
         array $rules,
         ?string $errorExpected = null,
         array $customRules = [],
-        array $exceptions = [],
-        ?array $expectedRequest = null
+        array $exceptions = []
     ): void
     {
         $this->requestMock->shouldReceive('getParsedBody')
@@ -71,7 +76,7 @@ class RequestValidationTest extends TestCase
      * @param array|null $expectedRequest
      * @group validation
      */
-    public function testRestDefailtDataPopulation(
+    public function testRestDefaultDataPopulation(
         array $requestBody,
         array $rules,
         ?array $expectedRequest = null

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -168,7 +168,7 @@ class RequestValidationTest extends TestCase
                 'errorExpected' => InvalidRequestParametersException::class,
                 'customRules' => [],
                 'customException' => [],
-                'expectedResult' => []
+                'expectedResult' => null
             ]
         ];
     }

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -157,6 +157,17 @@ class RequestValidationTest extends TestCase
                 'customException' => [],
                 'expectedResult' => ['paramName' => 'value1']
             ],
+            //preprocess data with empty body
+            [
+                'body' => [],
+                'rules' => [
+                    'paramName' => 'default:value1|in:value1,value2,value3'
+                ],
+                'errorExpected' => null,
+                'customRules' => [],
+                'customException' => [],
+                'expectedResult' => ['paramName' => 'value1']
+            ],
             //preprocess data with garbage values
             [
                 'body' => [

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -150,7 +150,7 @@ class RequestValidationTest extends TestCase
                     'paramName' => null,
                 ],
                 'rules' => [
-                    'paramName' => 'default:value1|required|in:value1,value2,value3'
+                    'paramName' => 'default:value1|in:value1,value2,value3'
                 ],
                 'errorExpected' => null,
                 'customRules' => [],
@@ -163,12 +163,12 @@ class RequestValidationTest extends TestCase
                     'paramName' => 'garbage value',
                 ],
                 'rules' => [
-                    'paramName' => 'default:value1|required|in:value1,value2,value3'
+                    'paramName' => 'default:value1|in:value1,value2,value3'
                 ],
                 'errorExpected' => InvalidRequestParametersException::class,
                 'customRules' => [],
                 'customException' => [],
-                'expectedResult' => ['paramName' => 'value1']
+                'expectedResult' => []
             ]
         ];
     }

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -156,6 +156,19 @@ class RequestValidationTest extends TestCase
                 'customRules' => [],
                 'customException' => [],
                 'expectedResult' => ['paramName' => 'value1']
+            ],
+            //preprocess data with garbage values
+            [
+                'body' => [
+                    'paramName' => 'garbage value',
+                ],
+                'rules' => [
+                    'paramName' => 'default:value1|required|in:value1,value2,value3'
+                ],
+                'errorExpected' => InvalidRequestParametersException::class,
+                'customRules' => [],
+                'customException' => [],
+                'expectedResult' => ['paramName' => 'value1']
             ]
         ];
     }

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -14,7 +14,6 @@ use Serato\SwsApp\Validation\RequestValidation;
 
 class RequestValidationTest extends TestCase
 {
-
     /**
      * @var RequestValidation
      */
@@ -30,6 +29,7 @@ class RequestValidationTest extends TestCase
         $this->validation = new RequestValidation();
         $this->requestMock = Mockery::mock(Request::class);
     }
+
     /**
      * @dataProvider dataProvider
      *
@@ -63,8 +63,6 @@ class RequestValidationTest extends TestCase
             $customRules,
             $exceptions
         );
-
-
     }
 
     /**
@@ -91,7 +89,6 @@ class RequestValidationTest extends TestCase
             $this->assertEqualsCanonicalizing($expectedRequest, $preprocessedRequest);
         }
     }
-
 
     /**
      * @return array


### PR DESCRIPTION
Previous validateRequestData implementation does not return any value.This avoids auto filling default values for input fields if no values were provided by the client.Change is added to return the preprocessed input with default values.
