### PR TITLE
[WEB-9021] Move input validations from Profile service to the bootstrap library

### DIFF
--- a/src/Exception/BadRequestContainHTMLTagsException.php
+++ b/src/Exception/BadRequestContainHTMLTagsException.php
@@ -5,11 +5,11 @@ namespace Serato\SwsApp\Exception;
 use Serato\SwsApp\Http\Rest\Exception\AbstractBadRequestException;
 
 /**
- * Class InvalidRequestParametersException
+ * Class BadRequestContainHTMLTagsException
  * The request param is invalid with html tags
  * @package App\Exception\RequestValidation
  */
-class InvalidTagRequestParametersException extends AbstractBadRequestException
+class BadRequestContainHTMLTagsException extends AbstractBadRequestException
 {
     /**
      * @var int

--- a/src/Exception/InvalidTagRequestParametersException.php
+++ b/src/Exception/InvalidTagRequestParametersException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Serato\SwsApp\Exception;
+
+use Serato\SwsApp\Http\Rest\Exception\AbstractBadRequestException;
+
+/**
+ * Class InvalidRequestParametersException
+ * The request param is invalid with html tags
+ * @package App\Exception\RequestValidation
+ */
+class InvalidTagRequestParametersException extends AbstractBadRequestException
+{
+    /**
+     * @var int
+     */
+    protected $code = 5023;
+
+    /**
+     * @var string
+     */
+    protected $message;
+}

--- a/src/Validation/RequestValidation.php
+++ b/src/Validation/RequestValidation.php
@@ -4,6 +4,7 @@ namespace Serato\SwsApp\Validation;
 
 use Serato\SwsApp\Exception\MissingRequiredParametersException;
 use Serato\SwsApp\Exception\InvalidRequestParametersException;
+use Serato\SwsApp\Exception\InvalidTagRequestParametersException;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Rakit\Validation\Validator;
 
@@ -71,6 +72,9 @@ class RequestValidation implements RequestValidationInterface
 
         if (!empty($invalid)) {
             $errors = implode('. ', $invalid);
+            if (strpos($errors, 'not valid format') !== false) {
+                throw new InvalidTagRequestParametersException($errors, $request);
+            }
             throw new InvalidRequestParametersException($errors, $request);
         }
     }

--- a/src/Validation/RequestValidation.php
+++ b/src/Validation/RequestValidation.php
@@ -81,7 +81,7 @@ class RequestValidation implements RequestValidationInterface
 
             foreach ($exceptions as $exceptionKey => $exception) {
                 if (!empty($error[$exceptionKey])) {
-                    throw new $exception('', $request);
+                    throw new $exception($error[$exceptionKey], $request);
                 }
             }
 

--- a/src/Validation/RequestValidation.php
+++ b/src/Validation/RequestValidation.php
@@ -7,6 +7,7 @@ use Serato\SwsApp\Exception\InvalidRequestParametersException;
 use Serato\SwsApp\Exception\InvalidTagRequestParametersException;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Rakit\Validation\Validator;
+use Rakit\Validation\Rules\Regex;
 
 /**
  * Class RequestValidation
@@ -52,7 +53,12 @@ class RequestValidation implements RequestValidationInterface
             }
             $validation->setAlias($ruleKey, '`' . $ruleKey . '`');
         }
-
+        if ($paramsContainHtmlTag) {
+            $customRules[self::NO_HTML_TAG_RULE] = new Regex();
+            if (!isset($exceptions['regex'])) {
+                $exceptions['regex'] = InvalidTagRequestParametersException::class;
+            }
+        }
         $validation->validate();
         if (!$validation->fails()) {
             return $validation->getValidatedData();
@@ -81,9 +87,6 @@ class RequestValidation implements RequestValidationInterface
         }
         if (!empty($invalid)) {
             $errors = implode('. ', $invalid);
-            if ($paramsContainHtmlTag) {
-                throw new InvalidTagRequestParametersException($errors, $request);
-            }
             throw new InvalidRequestParametersException($errors, $request);
         }
     }

--- a/src/Validation/RequestValidation.php
+++ b/src/Validation/RequestValidation.php
@@ -53,6 +53,7 @@ class RequestValidation implements RequestValidationInterface
             }
             $validation->setAlias($ruleKey, '`' . $ruleKey . '`');
         }
+        // add a customRule and customException when checking one param without html tag
         if ($paramsContainHtmlTag) {
             $customRules[self::NO_HTML_TAG_RULE] = new Regex();
             if (!isset($exceptions['regex'])) {

--- a/src/Validation/RequestValidation.php
+++ b/src/Validation/RequestValidation.php
@@ -31,11 +31,11 @@ class RequestValidation implements RequestValidationInterface
         $requestBody = $request->getParsedBody() ?? [];
         $validator   = new Validator();
 
-        // Register NoHtmlTag rule and set it's exception into BadRequestContainHTMLTagsException
-        if (in_array(NoHtmlTag::NO_HTML_TAG_RULE, $validationRules)) {
-            $validator->addValidator(NoHtmlTag::NO_HTML_TAG_RULE, new NoHtmlTag());
-            $exceptions[NoHtmlTag::NO_HTML_TAG_RULE] = BadRequestContainHTMLTagsException::class;
-        }
+        // add custom validators
+        $validator->addValidator(NoHtmlTag::NO_HTML_TAG_RULE, new NoHtmlTag());
+
+        // add custom exceptions
+        $exceptions[NoHtmlTag::NO_HTML_TAG_RULE] = BadRequestContainHTMLTagsException::class;
 
         // Add custom validation rules
         if (!empty($customRules)) {

--- a/src/Validation/RequestValidation.php
+++ b/src/Validation/RequestValidation.php
@@ -8,6 +8,7 @@ use Serato\SwsApp\Exception\BadRequestContainHTMLTagsException;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Rakit\Validation\Validator;
 use Rakit\Validation\Rules\Regex;
+use Serato\SwsApp\Validation\Rules\NoHtmlTag;
 
 /**
  * Class RequestValidation
@@ -15,18 +16,6 @@ use Rakit\Validation\Rules\Regex;
  */
 class RequestValidation implements RequestValidationInterface
 {
-    /**
-      * Validation rule name for params without HTML tags.
-      * @var string
-    */
-    public const NO_HTML_TAG_RULE = 'no_html_tag';
-
-    /**
-      * Regex validation rule for params without HTML tags.
-      * @var string
-    */
-    public const NO_HTML_TAG_REGEX = '/^(?:(?!<[^>]*$)[^<])*$/';
-
     /**
      * @param Request $request
      * @param array $validationRules
@@ -42,13 +31,10 @@ class RequestValidation implements RequestValidationInterface
         $requestBody = $request->getParsedBody() ?? [];
         $validator   = new Validator();
 
-        // Add a custom validation rule and exceptions when the `no_html_tag` validation rule is specified for a param.
-        // to prevent the need to include the Rakit Regex class in other services.
-        if (in_array(self::NO_HTML_TAG_RULE, $validationRules)) {
-            $noHtmlTagRule = new Regex();
-            $noHtmlTagRule->setParameter('regex', RequestValidation::NO_HTML_TAG_REGEX);
-            $customRules[self::NO_HTML_TAG_RULE] = $noHtmlTagRule;
-            $exceptions[self::NO_HTML_TAG_RULE] = BadRequestContainHTMLTagsException::class;
+        // Register NoHtmlTag rule and set it's exception into BadRequestContainHTMLTagsException
+        if (in_array(NoHtmlTag::NO_HTML_TAG_RULE, $validationRules)) {
+            $validator->addValidator(NoHtmlTag::NO_HTML_TAG_RULE, new NoHtmlTag());
+            $exceptions[NoHtmlTag::NO_HTML_TAG_RULE] = BadRequestContainHTMLTagsException::class;
         }
 
         // Add custom validation rules

--- a/src/Validation/RequestValidation.php
+++ b/src/Validation/RequestValidation.php
@@ -15,7 +15,7 @@ use Rakit\Validation\Validator;
 class RequestValidation implements RequestValidationInterface
 {
     /**
-      * Regex validation rule for parames without HTML tags.
+      * Regex validation rule for params without HTML tags.
       * @var string
     */
     public const NO_HTML_TAG_RULE = 'regex:/^(?:(?!<[^>]*$)[^<])*$/';

--- a/src/Validation/Rules/NoHtmlTag.php
+++ b/src/Validation/Rules/NoHtmlTag.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Serato\SwsApp\Validation\Rules;
+
+use Rakit\Validation\Rule;
+
+class NoHtmlTag extends Rule
+{
+    /**
+      * Validation rule name for params without HTML tags.
+      * @var string
+    */
+    public const NO_HTML_TAG_RULE = 'no_html_tag';
+    /**
+      * Regex validation rule for params without HTML tags.
+      * @var string
+    */
+    public const NO_HTML_TAG_REGEX = '/^(?:(?!<[^>]*$)[^<])*$/';
+
+    /** @var string */
+    protected $message = "The :attribute contains html tag.";
+
+    /**
+     * Check the $value is valid by checking it does not contain html tags
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function check($value): bool
+    {
+        return preg_match(self::NO_HTML_TAG_REGEX, $value) > 0;
+    }
+}

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -77,6 +77,14 @@ class RequestValidationTest extends TestCase
      */
     public function dataProvider(): array
     {
+        $noHtmlTagRule = new Regex();
+        $noHtmlTagRule->setParameter('regex', RequestValidation::NO_HTML_TAG_REGEX);
+
+        $paramStartWithARule = new Regex();
+        $paramStartWithARule->setParameter('regex', '/^a/');
+        // var_dump($noHtmlTagRule->getParameters());
+        // die;
+
         return [
             // no errors
             [
@@ -123,9 +131,15 @@ class RequestValidationTest extends TestCase
                     'paramName' => 'br'
                 ],
                 'rules' => [
-                    'paramName' => RequestValidation::NO_HTML_TAG_RULE
+                    'paramName' =>  RequestValidation::NO_HTML_TAG_RULE
                 ],
-                'errorExpected' => null
+                'errorExpected' => null,
+                'customRules' => [
+                    'no_html_tag' =>  $noHtmlTagRule
+                ],
+                'customException' => [
+                    'no_html_tag' => InvalidTagRequestParametersException::class
+                ]
             ],
             // invalid params contains html tags throw InvalidTagRequestParametersException
             [
@@ -135,7 +149,13 @@ class RequestValidationTest extends TestCase
                 'rules' => [
                     'paramName' => RequestValidation::NO_HTML_TAG_RULE
                 ],
-                'errorExpected' => InvalidTagRequestParametersException::class
+                'errorExpected' => InvalidTagRequestParametersException::class,
+                'customRules' => [
+                    'no_html_tag' =>  $noHtmlTagRule
+                ],
+                'customException' => [
+                    'no_html_tag' => InvalidTagRequestParametersException::class
+                ]
             ],
             // invalid params contains html tags throw InvalidTagRequestParametersException 2
             [
@@ -145,7 +165,13 @@ class RequestValidationTest extends TestCase
                 'rules' => [
                     'paramName' => RequestValidation::NO_HTML_TAG_RULE
                 ],
-                'errorExpected' => InvalidTagRequestParametersException::class
+                'errorExpected' => InvalidTagRequestParametersException::class,
+                'customRules' => [
+                    'no_html_tag' =>  $noHtmlTagRule
+                ],
+                'customException' => [
+                    'no_html_tag' => InvalidTagRequestParametersException::class
+                ]
             ],
             // invalid params contains html tags throw InvalidTagRequestParametersException 3
             [
@@ -155,7 +181,13 @@ class RequestValidationTest extends TestCase
                 'rules' => [
                     'paramName' => RequestValidation::NO_HTML_TAG_RULE
                 ],
-                'errorExpected' => InvalidTagRequestParametersException::class
+                'errorExpected' => InvalidTagRequestParametersException::class,
+                'customRules' => [
+                    'no_html_tag' =>  $noHtmlTagRule
+                ],
+                'customException' => [
+                    'no_html_tag' => InvalidTagRequestParametersException::class
+                ]
             ],
             // invalid params contains html tags throw InvalidTagRequestParametersException 4
             [
@@ -165,7 +197,13 @@ class RequestValidationTest extends TestCase
                 'rules' => [
                     'paramName' => RequestValidation::NO_HTML_TAG_RULE
                 ],
-                'errorExpected' => InvalidTagRequestParametersException::class
+                'errorExpected' => InvalidTagRequestParametersException::class,
+                'customRules' => [
+                    'no_html_tag' =>  $noHtmlTagRule
+                ],
+                'customException' => [
+                    'no_html_tag' => InvalidTagRequestParametersException::class
+                ]
             ],
             // invalid params contains invalid format throws InvalidRequestParametersException
             [
@@ -173,14 +211,14 @@ class RequestValidationTest extends TestCase
                     'paramName' => '<br>'
                 ],
                 'rules' => [
-                    'paramName' => 'regex:/^a/'
+                    'paramName' => 'start_with_a'
                 ],
                 'errorExpected' => InvalidRequestParametersException::class,
                 'customRules' => [
-                    'regex:/^a/' => new Regex()
+                    'start_with_a' => $paramStartWithARule
                 ],
                 'customException' => [
-                    'regex' => InvalidRequestParametersException::class
+                    'start_with_a' => InvalidRequestParametersException::class
                 ]
             ],
             // invalid params contains invalid format and html tags throws InvalidRequestParametersException
@@ -190,15 +228,17 @@ class RequestValidationTest extends TestCase
                     'paramName2' => '<a>'
                 ],
                 'rules' => [
-                    'paramName' => 'regex:/^a/', // any string start with `a`
+                    'paramName' => 'start_with_a',
                     'paramName2' => RequestValidation::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => InvalidRequestParametersException::class,
                 'customRules' => [
-                    'regex:/^a/' => new Regex()
+                  'start_with_a' => $paramStartWithARule,
+                  'no_html_tag' =>  $noHtmlTagRule
                 ],
                 'customException' => [
-                    'regex' => InvalidRequestParametersException::class
+                    'start_with_a' => InvalidRequestParametersException::class,
+                    'no_html_tag' => InvalidTagRequestParametersException::class
                 ]
             ],
             // custom rule
@@ -226,10 +266,12 @@ class RequestValidationTest extends TestCase
                 ],
                 'errorExpected' => null,
                 'customRules' => [
-                    'is_numeric' => new Numeric()
+                    'is_numeric' => new Numeric(),
+                    'no_html_tag' =>  $noHtmlTagRule
                 ],
                 'customException' => [
-                    'is_numeric' => UnsupportedContentTypeException::class
+                    'is_numeric' => UnsupportedContentTypeException::class,
+                    'no_html_tag' => InvalidTagRequestParametersException::class
                 ]
             ],
             // custom exception
@@ -260,14 +302,16 @@ class RequestValidationTest extends TestCase
                 ],
                 'errorExpected' => UnsupportedContentTypeException::class,
                 'customRules' => [
-                    'is_numeric' => new Numeric()
+                    'is_numeric' => new Numeric(),
+                    'no_html_tag' =>  $noHtmlTagRule
                 ],
                 'customException' => [
-                    'is_numeric' => UnsupportedContentTypeException::class
+                    'is_numeric' => UnsupportedContentTypeException::class,
+                    'no_html_tag' => InvalidTagRequestParametersException::class
                 ]
             ],
             // custom exception and invalid params contains html tags throws InvalidTagRequestParametersException
-            // (params order change)
+            // (params order changed)
             [
                 'body' => [
                     'paramName' => '<br>',
@@ -279,9 +323,11 @@ class RequestValidationTest extends TestCase
                 ],
                 'errorExpected' => InvalidTagRequestParametersException::class,
                 'customRules' => [
+                    'no_html_tag' =>  $noHtmlTagRule,
                     'is_numeric' => new Numeric()
                 ],
                 'customException' => [
+                    'no_html_tag' => InvalidTagRequestParametersException::class,
                     'is_numeric' => UnsupportedContentTypeException::class
                 ]
             ],

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -122,7 +122,7 @@ class RequestValidationTest extends TestCase
                     'paramName' => '<a>'
                 ],
                 'rules' => [
-                  'paramName' => 'regex:/^(?:(?!<[a-zA-Z])[\s\S])*$/'
+                  'paramName' => 'regex:/^(?:(?!<[^>]*$)[^<])*$/'
                 ],
                 'errorExpected' => InvalidTagRequestParametersException::class,
             ],

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Rakit\Validation\RuleNotFoundException;
 use Rakit\Validation\Rules\Numeric;
 use Rakit\Validation\Rules\Regex;
+use Serato\SwsApp\Validation\Rules\NoHtmlTag;
 use Serato\SwsApp\Exception\InvalidRequestParametersException;
 use Serato\SwsApp\Exception\BadRequestContainHTMLTagsException;
 use Serato\SwsApp\Exception\MissingRequiredParametersException;
@@ -125,7 +126,7 @@ class RequestValidationTest extends TestCase
                     'paramName' => 'br'
                 ],
                 'rules' => [
-                    'paramName' =>  RequestValidation::NO_HTML_TAG_RULE
+                    'paramName' =>  NoHtmlTag::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => null
             ],
@@ -145,7 +146,7 @@ class RequestValidationTest extends TestCase
                     'paramName' => '<br>'
                 ],
                 'rules' => [
-                    'paramName' => RequestValidation::NO_HTML_TAG_RULE
+                    'paramName' => NoHtmlTag::NO_HTML_TAG_RULE,
                 ],
                 'errorExpected' => BadRequestContainHTMLTagsException::class,
             ],
@@ -155,7 +156,7 @@ class RequestValidationTest extends TestCase
                     'paramName' => '<a>test</a>'
                 ],
                 'rules' => [
-                    'paramName' => RequestValidation::NO_HTML_TAG_RULE
+                    'paramName' => NoHtmlTag::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => BadRequestContainHTMLTagsException::class
             ],
@@ -165,7 +166,7 @@ class RequestValidationTest extends TestCase
                     'paramName' => '<fake></fake>'
                 ],
                 'rules' => [
-                    'paramName' => RequestValidation::NO_HTML_TAG_RULE
+                    'paramName' => NoHtmlTag::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => BadRequestContainHTMLTagsException::class
             ],
@@ -175,7 +176,7 @@ class RequestValidationTest extends TestCase
                     'paramName' => 'test</a>'
                 ],
                 'rules' => [
-                    'paramName' => RequestValidation::NO_HTML_TAG_RULE
+                    'paramName' => NoHtmlTag::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => BadRequestContainHTMLTagsException::class
             ],
@@ -203,7 +204,7 @@ class RequestValidationTest extends TestCase
                 ],
                 'rules' => [
                     'paramName' => 'start_with_a',
-                    'paramName2' => RequestValidation::NO_HTML_TAG_RULE
+                    'paramName2' => NoHtmlTag::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => InvalidRequestParametersException::class,
                 'customRules' => [
@@ -234,7 +235,7 @@ class RequestValidationTest extends TestCase
                 ],
                 'rules' => [
                     'paramName' => 'required|is_numeric',
-                    'paramName2' => RequestValidation::NO_HTML_TAG_RULE
+                    'paramName2' => NoHtmlTag::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => null,
                 'customRules' => [
@@ -268,7 +269,7 @@ class RequestValidationTest extends TestCase
                 ],
                 'rules' => [
                     'paramName' => 'required|is_numeric',
-                    'paramName2' => RequestValidation::NO_HTML_TAG_RULE
+                    'paramName2' => NoHtmlTag::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => UnsupportedContentTypeException::class,
                 'customRules' => [
@@ -286,7 +287,7 @@ class RequestValidationTest extends TestCase
                     'paramName2' => 'invalid-number',
                 ],
                 'rules' => [
-                    'paramName' => RequestValidation::NO_HTML_TAG_RULE,
+                    'paramName' => NoHtmlTag::NO_HTML_TAG_RULE,
                     'paramName2' => 'required|is_numeric',
                 ],
                 'errorExpected' => BadRequestContainHTMLTagsException::class,

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -117,6 +117,16 @@ class RequestValidationTest extends TestCase
                 ],
                 'errorExpected' => RuleNotFoundException::class,
             ],
+            // valid params without html tags throw no error
+            [
+                'body' => [
+                    'paramName' => 'br'
+                ],
+                'rules' => [
+                    'paramName' => RequestValidation::NO_HTML_TAG_RULE
+                ],
+                'errorExpected' => null
+            ],
             // invalid params contains html tags throw InvalidTagRequestParametersException
             [
                 'body' => [
@@ -197,11 +207,11 @@ class RequestValidationTest extends TestCase
                     'paramName' => '1'
                 ],
                 'rules' => [
-                    'paramName' => 'required|is_numberic'
+                    'paramName' => 'required|is_numeric'
                 ],
                 'errorExpected' => null,
                 'customRules' => [
-                    'is_numberic' => new Numeric()
+                    'is_numeric' => new Numeric()
                 ]
             ],
             // custom rule and invalid params contains html tags not excepting errors
@@ -211,15 +221,15 @@ class RequestValidationTest extends TestCase
                     'paramNam2' => '<a>'
                 ],
                 'rules' => [
-                    'paramName' => 'required|is_numberic',
+                    'paramName' => 'required|is_numeric',
                     'paramName2' => RequestValidation::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => null,
                 'customRules' => [
-                    'is_numberic' => new Numeric()
+                    'is_numeric' => new Numeric()
                 ],
                 'customException' => [
-                    'is_numberic' => UnsupportedContentTypeException::class
+                    'is_numeric' => UnsupportedContentTypeException::class
                 ]
             ],
             // custom exception
@@ -228,14 +238,14 @@ class RequestValidationTest extends TestCase
                     'paramName' => 'invalid-number'
                 ],
                 'rules' => [
-                    'paramName' => 'required|is_numberic'
+                    'paramName' => 'required|is_numeric'
                 ],
                 'errorExpected' => UnsupportedContentTypeException::class,
                 'customRules' => [
-                    'is_numberic' => new Numeric()
+                    'is_numeric' => new Numeric()
                 ],
                 'customException' => [
-                    'is_numberic' => UnsupportedContentTypeException::class
+                    'is_numeric' => UnsupportedContentTypeException::class
                 ]
             ],
             // custom exception and invalid params contains html tags throws UnsupportedContentTypeException
@@ -245,15 +255,34 @@ class RequestValidationTest extends TestCase
                     'paramName2' => '<br>'
                 ],
                 'rules' => [
-                    'paramName' => 'required|is_numberic',
+                    'paramName' => 'required|is_numeric',
                     'paramName2' => RequestValidation::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => UnsupportedContentTypeException::class,
                 'customRules' => [
-                    'is_numberic' => new Numeric()
+                    'is_numeric' => new Numeric()
                 ],
                 'customException' => [
-                    'is_numberic' => UnsupportedContentTypeException::class
+                    'is_numeric' => UnsupportedContentTypeException::class
+                ]
+            ],
+            // custom exception and invalid params contains html tags throws InvalidTagRequestParametersException 
+            // (params order change)
+            [
+                'body' => [
+                    'paramName' => '<br>',
+                    'paramName2' => 'invalid-number',
+                ],
+                'rules' => [
+                    'paramName' => RequestValidation::NO_HTML_TAG_RULE,
+                    'paramName2' => 'required|is_numeric',
+                ],
+                'errorExpected' => InvalidTagRequestParametersException::class,
+                'customRules' => [
+                    'is_numeric' => new Numeric()
+                ],
+                'customException' => [
+                    'is_numeric' => InvalidTagRequestParametersException::class
                 ]
             ],
             //preprocess data with default values

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -282,7 +282,7 @@ class RequestValidationTest extends TestCase
                     'is_numeric' => new Numeric()
                 ],
                 'customException' => [
-                    'is_numeric' => InvalidTagRequestParametersException::class
+                    'is_numeric' => UnsupportedContentTypeException::class
                 ]
             ],
             //preprocess data with default values

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -122,7 +122,7 @@ class RequestValidationTest extends TestCase
                     'paramName' => '<a>'
                 ],
                 'rules' => [
-                  'paramName' => 'regex:/^(?:(?!<[^>]*$)[^<])*$/'
+                  'paramName' => RequestValidation::NO_HTML_TAG_RULE
                 ],
                 'errorExpected' => InvalidTagRequestParametersException::class,
             ],

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -127,6 +127,36 @@ class RequestValidationTest extends TestCase
                 ],
                 'errorExpected' => InvalidTagRequestParametersException::class
             ],
+            // invalid params contains html tags throw InvalidTagRequestParametersException 2
+            [
+                'body' => [
+                    'paramName' => '<a>test</a>'
+                ],
+                'rules' => [
+                    'paramName' => RequestValidation::NO_HTML_TAG_RULE
+                ],
+                'errorExpected' => InvalidTagRequestParametersException::class
+            ],
+            // invalid params contains html tags throw InvalidTagRequestParametersException 3
+            [
+                'body' => [
+                    'paramName' => '<fake></fake>'
+                ],
+                'rules' => [
+                    'paramName' => RequestValidation::NO_HTML_TAG_RULE
+                ],
+                'errorExpected' => InvalidTagRequestParametersException::class
+            ],
+            // invalid params contains html tags throw InvalidTagRequestParametersException 4
+            [
+                'body' => [
+                    'paramName' => 'test</a>'
+                ],
+                'rules' => [
+                    'paramName' => RequestValidation::NO_HTML_TAG_RULE
+                ],
+                'errorExpected' => InvalidTagRequestParametersException::class
+            ],
             // invalid params contains invalid format throws InvalidRequestParametersException
             [
                 'body' => [

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Rakit\Validation\RuleNotFoundException;
 use Rakit\Validation\Rules\Numeric;
 use Serato\SwsApp\Exception\InvalidRequestParametersException;
+use Serato\SwsApp\Exception\InvalidTagRequestParametersException;
 use Serato\SwsApp\Exception\MissingRequiredParametersException;
 use Serato\SwsApp\Http\Rest\Exception\UnsupportedContentTypeException;
 use Serato\SwsApp\Test\TestCase;
@@ -114,6 +115,16 @@ class RequestValidationTest extends TestCase
                     'paramName' => 'invalid'
                 ],
                 'errorExpected' => RuleNotFoundException::class,
+            ],
+            // invalid params contains html tags
+            [
+                'body' => [
+                    'paramName' => '<a>'
+                ],
+                'rules' => [
+                  'paramName' => 'regex:/^(?:(?!<[a-zA-Z])[\s\S])*$/'
+                ],
+                'errorExpected' => InvalidTagRequestParametersException::class,
             ],
             // custom rule
             [

--- a/tests/Validation/RequestValidationTest.php
+++ b/tests/Validation/RequestValidationTest.php
@@ -266,7 +266,7 @@ class RequestValidationTest extends TestCase
                     'is_numeric' => UnsupportedContentTypeException::class
                 ]
             ],
-            // custom exception and invalid params contains html tags throws InvalidTagRequestParametersException 
+            // custom exception and invalid params contains html tags throws InvalidTagRequestParametersException
             // (params order change)
             [
                 'body' => [


### PR DESCRIPTION
throw 5023 if request param contains html tag